### PR TITLE
Ensure that only egress traffic is blocked and ingress traffic is allowed.

### DIFF
--- a/firewaller/update-firewall.sh
+++ b/firewaller/update-firewall.sh
@@ -33,7 +33,8 @@ function update {
     echo "Ipset \"$2\" initially created successfully."
     local DEFAULT_NET_DEVICE=`ip route | grep default | awk '{print $5}'`
     echo "Initially creating ip${1}tables rule for device \"${DEFAULT_NET_DEVICE}\" referencing ipset..."
-    ip${1}tables -t mangle -A POSTROUTING -o ${DEFAULT_NET_DEVICE} -m set --match-set $2 dst -j DROP
+    ip${1}tables -t mangle -A POSTROUTING -o ${DEFAULT_NET_DEVICE} -p tcp --syn -m set --match-set $2 dst -j DROP
+    ip${1}tables -t mangle -A POSTROUTING -o ${DEFAULT_NET_DEVICE} -p udp -m set --match-set $2 dst -j DROP
     echo "Initial ip${1}tables rule for device \"${DEFAULT_NET_DEVICE}\" created successfully."
   else
     set -e


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensure that only egress traffic is blocked and ingress traffic is allowed.

To block egress traffic outgoing syn packets are dropped so that no tcp
connection can be established. udp traffic is dropped as well.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Ensure that only egress traffic is blocked and ingress traffic is allowed.
```

/cc @DockToFuture