### PR TITLE
Build arm64 based images

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,6 +7,10 @@ egress-filter-refresher:
         preprocess:
           'inject-commit-hash'
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           egress-filter-refresher:
             inputs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Similar to https://github.com/gardener/vpn2/pull/9. 

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/backlog/issues/19

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Container images are now built and published also for `arm64` platforms.
```
