### PR TITLE
Add iptables backend detection.

### DIFF
--- a/pkg/netconfig/netconfig.go
+++ b/pkg/netconfig/netconfig.go
@@ -41,6 +41,7 @@ func GetDefaultNetworkDevice(ipVersion string) (string, error) {
 }
 
 func InitLoggingChain(ipVersion string) error {
+	DefaultNetUtilsCommandExecutor.DetermineIPTablesBackend()
 	err := DefaultNetUtilsCommandExecutor.ExecuteIPTablesCommand(ipVersion, "-t", "mangle", "-L", ipTablesLoggingChain)
 	if err != nil {
 		err := DefaultNetUtilsCommandExecutor.ExecuteIPTablesCommand(ipVersion, "-t", "mangle", "-N", ipTablesLoggingChain)

--- a/pkg/netconfig/netconfig_test.go
+++ b/pkg/netconfig/netconfig_test.go
@@ -19,6 +19,7 @@ var _ = Describe("Netconfig", func() {
 
 	BeforeEach(func() {
 		mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
+		mockExecutor.DetermineIPTablesBackend()
 		mockExecutor.MockIPRoutesStdOut = bytes.NewBufferString("default via 10.242.0.1 dev ens5 proto dhcp src 10.242.0.198 metric 1024")
 		netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
 
@@ -54,9 +55,9 @@ var _ = Describe("Netconfig", func() {
 			err := netconfig.InitLoggingChain("4")
 			Expect(err).To(BeNil())
 			Expect(len(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds)).To(Equal(3))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[0].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-L", "POLICY_LOGGING"}))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[1].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-C", "POLICY_LOGGING", "-m", "limit", "--limit", "10/min", "-j", "LOG", "--log-prefix", "Policy-Filter-Dropped:", "--log-level", "4"}))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[2].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-C", "POLICY_LOGGING", "-j", "DROP"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[0].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-L", "POLICY_LOGGING"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[1].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-C", "POLICY_LOGGING", "-m", "limit", "--limit", "10/min", "-j", "LOG", "--log-prefix", "Policy-Filter-Dropped:", "--log-level", "4"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[2].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-C", "POLICY_LOGGING", "-j", "DROP"}))
 		})
 		It("calls the correct command if chain and rules don't exist", func() {
 			mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
@@ -65,12 +66,12 @@ var _ = Describe("Netconfig", func() {
 			err := netconfig.InitLoggingChain("4")
 			Expect(err).To(BeNil())
 			Expect(len(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds)).To(Equal(6))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[0].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-L", "POLICY_LOGGING"}))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[1].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-N", "POLICY_LOGGING"}))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[2].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-C", "POLICY_LOGGING", "-m", "limit", "--limit", "10/min", "-j", "LOG", "--log-prefix", "Policy-Filter-Dropped:", "--log-level", "4"}))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[3].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-A", "POLICY_LOGGING", "-m", "limit", "--limit", "10/min", "-j", "LOG", "--log-prefix", "Policy-Filter-Dropped:", "--log-level", "4"}))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[4].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-C", "POLICY_LOGGING", "-j", "DROP"}))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[5].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-A", "POLICY_LOGGING", "-j", "DROP"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[0].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-L", "POLICY_LOGGING"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[1].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-N", "POLICY_LOGGING"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[2].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-C", "POLICY_LOGGING", "-m", "limit", "--limit", "10/min", "-j", "LOG", "--log-prefix", "Policy-Filter-Dropped:", "--log-level", "4"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[3].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-A", "POLICY_LOGGING", "-m", "limit", "--limit", "10/min", "-j", "LOG", "--log-prefix", "Policy-Filter-Dropped:", "--log-level", "4"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[4].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-C", "POLICY_LOGGING", "-j", "DROP"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[5].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-A", "POLICY_LOGGING", "-j", "DROP"}))
 		})
 	})
 
@@ -83,13 +84,13 @@ var _ = Describe("Netconfig", func() {
 				Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[0].Args).To(Equal(expectedArgs))
 			},
 			Entry("add rule", "", "tcp", "test-ipset", "ens5", false, []string{
-				"iptables", "-w", "-t", "mangle", "-A", "POSTROUTING", "-o", "ens5", "-p", "tcp", "--syn", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING",
+				"iptables-legacy", "-w", "-t", "mangle", "-A", "POSTROUTING", "-o", "ens5", "-p", "tcp", "--syn", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING",
 			}),
 			Entry("check rule", "", "udp", "test-ipset", "ens5", true, []string{
-				"iptables", "-w", "-t", "mangle", "-C", "POSTROUTING", "-o", "ens5", "-p", "udp", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING",
+				"iptables-legacy", "-w", "-t", "mangle", "-C", "POSTROUTING", "-o", "ens5", "-p", "udp", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING",
 			}),
 			Entry("add rule with different ip version", "6", "tcp", "test-ipset", "ens5", false, []string{
-				"ip6tables", "-w", "-t", "mangle", "-A", "POSTROUTING", "-o", "ens5", "-p", "tcp", "--syn", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING",
+				"ip6tables-legacy", "-w", "-t", "mangle", "-A", "POSTROUTING", "-o", "ens5", "-p", "tcp", "--syn", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING",
 			}),
 		)
 	})
@@ -100,11 +101,12 @@ var _ = Describe("Netconfig", func() {
 			err := netconfig.AddIPTablesLoggingRules("4", "test-ipset", "ens5", false)
 			Expect(err).To(BeNil())
 			Expect(len(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds)).To(Equal(2))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[0].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-C", "POSTROUTING", "-o", "ens5", "-p", "tcp", "--syn", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[1].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-C", "POSTROUTING", "-o", "ens5", "-p", "udp", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[0].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-C", "POSTROUTING", "-o", "ens5", "-p", "tcp", "--syn", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[1].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-C", "POSTROUTING", "-o", "ens5", "-p", "udp", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
 		})
 		It("makes the right calls to iptables if rules don't exist", func() {
 			mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
+			mockExecutor.DetermineIPTablesBackend()
 			mockExecutor.MockIPRoutesStdOut = bytes.NewBufferString("default via 10.242.0.1 dev ens5 proto dhcp src 10.242.0.198 metric 1024")
 			mockExecutor.MockCheckError = errors.New("iptables: Bad rule (does a matching rule exist in that chain?).")
 			netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
@@ -112,10 +114,10 @@ var _ = Describe("Netconfig", func() {
 			err := netconfig.AddIPTablesLoggingRules("4", "test-ipset", "ens5", false)
 			Expect(err).To(BeNil())
 			Expect(len(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds)).To(Equal(4))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[0].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-C", "POSTROUTING", "-o", "ens5", "-p", "tcp", "--syn", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[1].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-A", "POSTROUTING", "-o", "ens5", "-p", "tcp", "--syn", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[2].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-C", "POSTROUTING", "-o", "ens5", "-p", "udp", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[3].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-A", "POSTROUTING", "-o", "ens5", "-p", "udp", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[0].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-C", "POSTROUTING", "-o", "ens5", "-p", "tcp", "--syn", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[1].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-A", "POSTROUTING", "-o", "ens5", "-p", "tcp", "--syn", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[2].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-C", "POSTROUTING", "-o", "ens5", "-p", "udp", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[3].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-A", "POSTROUTING", "-o", "ens5", "-p", "udp", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
 
 		})
 	})
@@ -174,8 +176,8 @@ line with []
 			Expect(len(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds)).To(Equal(6))
 			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[0].Args).To(Equal([]string{"ipset", "create", "tmpIPSet", "hash:net", "family", "inet", "maxelem", "65536"}))
 			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[1].Args).To(Equal([]string{"ipset", "-"}))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[2].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-C", "POSTROUTING", "-o", "ens5", "-p", "tcp", "--syn", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
-			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[3].Args).To(Equal([]string{"iptables", "-w", "-t", "mangle", "-C", "POSTROUTING", "-o", "ens5", "-p", "udp", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[2].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-C", "POSTROUTING", "-o", "ens5", "-p", "tcp", "--syn", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[3].Args).To(Equal([]string{"iptables-legacy", "-w", "-t", "mangle", "-C", "POSTROUTING", "-o", "ens5", "-p", "udp", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING"}))
 			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[4].Args).To(Equal([]string{"ipset", "swap", "tmpIPSet", "test-ipset"}))
 			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[5].Args).To(Equal([]string{"ipset", "destroy", "tmpIPSet"}))
 		})

--- a/pkg/netconfig/netutils.go
+++ b/pkg/netconfig/netutils.go
@@ -34,8 +34,19 @@ func (r *OSNetUtilsCommandExecutor) DetermineIPTablesBackend() {
 	if err != nil {
 		return
 	}
-	output := out.String()
-	if !strings.Contains(output, "KUBE-IPTABLES-HINT") && !strings.Contains(output, "KUBE-KUBELET-CANARY") {
+	outputV4 := out.String()
+
+	r.ipTablesBackend = "legacy"
+	cmd = exec.Command("ip6tables-legacy-save")
+
+	cmd.Stdout = &out
+	err = cmd.Run()
+	if err != nil {
+		return
+	}
+	outputV6 := out.String()
+
+	if !strings.Contains(outputV4, "KUBE-IPTABLES-HINT") && !strings.Contains(outputV4, "KUBE-KUBELET-CANARY") && !strings.Contains(outputV6, "KUBE-IPTABLES-HINT") && !strings.Contains(outputV6, "KUBE-KUBELET-CANARY") {
 		r.ipTablesBackend = "nft"
 	}
 }

--- a/pkg/netconfig/netutils.go
+++ b/pkg/netconfig/netutils.go
@@ -115,7 +115,7 @@ func (m *MockNetUtilsCommandExecutor) ExecuteIPTablesCommand(ipVersion string, a
 		ipVersion = ""
 	}
 	args = append([]string{"-w"}, args...)
-	cmd := exec.Command("ip"+ipVersion+"tables", args...)
+	cmd := exec.Command("ip"+ipVersion+"tables-"+m.ipTablesBackend, args...)
 	m.MockCmds = append(m.MockCmds, cmd)
 	if args[3] == "-C" || args[3] == "-L" {
 		return m.MockCheckError
@@ -146,6 +146,6 @@ func (m *MockNetUtilsCommandExecutor) ExecuteIPRouteBatchCommand(ipVersion, scri
 	return nil
 }
 
-func (r *MockNetUtilsCommandExecutor) DetermineIPTablesBackend() {
-	r.ipTablesBackend = "legacy"
+func (m *MockNetUtilsCommandExecutor) DetermineIPTablesBackend() {
+	m.ipTablesBackend = "legacy"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
As of 1.24, Kubelet always creates a chain named KUBE-IPTABLES-HINT in the mangle table of whichever iptables subsystem it is using. Components can now look for this specific chain to know which iptables subsystem Kubelet (and thus, presumably, the rest of the system) is using.

(Additionally, since Kubernetes 1.17, kubelet has created a chain called KUBE-KUBELET-CANARY in the mangle table. While this chain may go away in the future, it will of course still be there in older releases, so in any recent version of Kubernetes, at least one of KUBE-IPTABLES-HINT or KUBE-KUBELET-CANARY will be present.)

https://kubernetes.io/blog/2022/09/07/iptables-chains-not-api/#use-case-iptables-mode

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add iptables backend detection.
```
