### PR TITLE
fix: prepareAddrs trims /128 suffixes for ipv6 filters

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -54,7 +54,7 @@ func updateFirewall(blockIngress bool, ipv4EgressFilterList, ipv6EgressFilterLis
 	defaultNetworkDevices := []string{defaultNetworkDeviceV4, defaultNetworkDeviceV6}
 
 	for i, v := range []string{"4", "6"} {
-		netconfig.InitIPSet(v, ipSetNames[i])
+		_ = netconfig.InitIPSet(v, ipSetNames[i])
 		egressFilterContent, err := os.ReadFile(filterLists[i])
 		if err != nil {
 			return fmt.Errorf("error reading egress filter list '%s': %v", filterLists[i], err)
@@ -85,8 +85,8 @@ func main() {
 	fmt.Printf("blackholing enabled: %v\n", blackholing)
 	for {
 		fmt.Println(time.Now())
-		netconfig.InitLoggingChain("4")
-		netconfig.InitLoggingChain("6")
+		_ = netconfig.InitLoggingChain("4")
+		_ = netconfig.InitLoggingChain("6")
 		if blackholing {
 			err := netconfig.InitDummyDevice()
 			if err != nil {

--- a/pkg/netconfig/netconfig.go
+++ b/pkg/netconfig/netconfig.go
@@ -138,8 +138,9 @@ func prepareAddrs(content string, trimSuffix bool) []string {
 		if !strings.Contains(line, "[]") {
 			if len(strings.Fields(line)) == 2 {
 				addr := strings.Fields(line)[1]
-				if trimSuffix && strings.HasSuffix(addr, "/32") {
+				if trimSuffix {
 					addr = strings.TrimSuffix(addr, "/32")
+					addr = strings.TrimSuffix(addr, "/128")
 				}
 				res = append(res, addr)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Single-host IPv6 addresses may show as `2401:4900:33d5:4afa:9d59:6c45:239f:8ead/128` on the filter list but as `2401:4900:33d5:4afa:9d59:6c45:239f:8ead` on the `ip route` output. 

This can cause problems where such addresses are falsely recognized as a diff that needs to be added to the blackholed routes, even though it is already blackholed.

The symptom shows as
```
Checking ipv6 egress filter list with 995 entries against current settings...
Currently applied filter list contains 995 entries
Adding 1 routes.
Error updating blackhole routes: updateRoutes failed for IPv6: error adding blackhole routes: exit status 1
```

So both current list and new list have the same number of entries, but still one entry is to be added.

**Special notes for your reviewer**:
- Updated tests to reflect the change.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
fixed a bug where non-suffixed IPv6 addresses could cause the egress filter applier to crash.
```
