### PR TITLE
Cleanup old egress rules after applying a new blocking mode 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 ARG TARGETARCH
 RUN make build-filter-updater GOARCH=$TARGETARCH
 
-FROM alpine:3.20.3 as builder
+FROM alpine:3.20.3 AS builder
 
 WORKDIR /volume
 
@@ -50,4 +50,4 @@ FROM scratch
 
 COPY --from=builder /volume /
 
-CMD /filter-updater
+CMD ["/filter-updater"]

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ IMAGE_REPOSITORY            := $(REGISTRY)/$(NAME)
 IMAGE_TAG                   := $(VERSION)
 EFFECTIVE_VERSION           := $(VERSION)-$(shell git rev-parse HEAD)
 GOARCH                      := amd64
+PLATFORM                    := linux/amd64
 REPO_ROOT                   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 TOOLS_DIR := hack/tools
@@ -53,7 +54,7 @@ build-filter-updater:
 
 .PHONY: docker-images
 docker-images:
-	@docker build -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) -f Dockerfile --rm .
+	@docker build --platform $(PLATFORM) -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) -f Dockerfile --rm .
 
 .PHONY: release
 release: docker-images docker-login docker-push

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -111,7 +111,7 @@ func cleanupFirewall() error {
 		}
 		err = netconfig.RemoveIPSet(ipSetNames[i])
 		if err != nil {
-			return fmt.Errorf("RemoveIPSet failed for %s: %v", ipSetNames[i], err)
+			return fmt.Errorf("RemoveIPSet failed for %s: %w", ipSetNames[i], err)
 		}
 	}
 

--- a/pkg/netconfig/netconfig.go
+++ b/pkg/netconfig/netconfig.go
@@ -24,12 +24,11 @@ var (
 )
 
 func GetDefaultNetworkDevice(ipVersion string) (string, error) {
-	out, err := DefaultNetUtilsCommandExecutor.ExecuteIPRouteCommand(ipVersion, "route", "show", "default")
+	output, err := DefaultNetUtilsCommandExecutor.ExecuteIPRouteCommand(ipVersion, "route", "show", "default")
 	if err != nil {
 		return "", err
 	}
 
-	output := out.String()
 	fields := strings.Fields(output)
 	for i, field := range fields {
 		if field == "dev" {
@@ -279,7 +278,7 @@ func diff(new, old []string) (added, removed []string) {
 
 func InitDummyDevice() error {
 	out, _ := DefaultNetUtilsCommandExecutor.ExecuteIPRouteCommand("4", "link", "show")
-	if !strings.Contains(out.String(), " "+dummyDeviceName+": ") {
+	if !strings.Contains(out, " "+dummyDeviceName+": ") {
 		_, err := DefaultNetUtilsCommandExecutor.ExecuteIPRouteCommand("4", "link", "add", dummyDeviceName, "type", "dummy")
 		if err != nil {
 			return fmt.Errorf("error creating dummy device: %v", err)
@@ -324,7 +323,7 @@ func RemoveDummyDevice() error {
 	}
 
 	out, _ := DefaultNetUtilsCommandExecutor.ExecuteIPRouteCommand("4", "link", "show")
-	if strings.Contains(out.String(), " "+dummyDeviceName+": ") {
+	if strings.Contains(out, " "+dummyDeviceName+": ") {
 		_, err := DefaultNetUtilsCommandExecutor.ExecuteIPRouteCommand("4", "link", "set", dummyDeviceName, "down")
 		if err != nil {
 			return fmt.Errorf("error bringing down dummy device: %w", err)
@@ -349,7 +348,7 @@ func GetBlackholeRoutes(ipVersion string) ([]string, error) {
 		return blackholeRoutes, err
 	}
 
-	lines := strings.Split(ipOut.String(), "\n")
+	lines := strings.Split(ipOut, "\n")
 	for _, line := range lines {
 		if strings.Contains(line, dummyDeviceName) && !strings.Contains(line, "fe80::/64") {
 			fields := strings.Fields(line)

--- a/pkg/netconfig/netconfig.go
+++ b/pkg/netconfig/netconfig.go
@@ -141,6 +141,7 @@ func RemoveIPTablesLoggingRules(ipVersion, ipSet, defaultNetworkDevice string) e
 			return fmt.Errorf("error deleting udp logging chain rules for %s, device %s %v", ipSet, defaultNetworkDevice, err)
 		}
 	}
+	fmt.Printf("Removed iptables v%s rules for ipset %s on device %s\n", ipVersion, ipSet, defaultNetworkDevice)
 	return nil
 }
 
@@ -235,12 +236,7 @@ func UpdateIPSet(ipVersion, ipSetName, egressFilterList, defaultNetworkDevice st
 	return nil
 }
 
-func RemoveIPSet(ipVersion, ipSetName, defaultNetworkDevice string) error {
-	err := RemoveIPTablesLoggingRules(ipVersion, ipSetName, defaultNetworkDevice)
-	if err != nil {
-		return fmt.Errorf("error removing iptables rules %w", err)
-	}
-
+func RemoveIPSet(ipSetName string) error {
 	if err := DefaultNetUtilsCommandExecutor.ExecuteIPSetCommand("list", ipSetName); err == nil {
 		err = DefaultNetUtilsCommandExecutor.ExecuteIPSetCommand("destroy", ipSetName)
 		if err != nil {
@@ -248,7 +244,8 @@ func RemoveIPSet(ipVersion, ipSetName, defaultNetworkDevice string) error {
 		}
 	}
 
-	return err
+	fmt.Printf("Removed ipset %s\n", ipSetName)
+	return nil
 }
 
 // blackholer

--- a/pkg/netconfig/netconfig.go
+++ b/pkg/netconfig/netconfig.go
@@ -312,14 +312,14 @@ func RemoveDummyDevice() error {
 	if err := DefaultNetUtilsCommandExecutor.ExecuteIPTablesCommand("4", "-t", "mangle", "-C", "POSTROUTING", "-o", dummyDeviceName, "-j", ipTablesLoggingChain); err == nil {
 		err = DefaultNetUtilsCommandExecutor.ExecuteIPTablesCommand("4", "-t", "mangle", "-D", "POSTROUTING", "-o", dummyDeviceName, "-j", ipTablesLoggingChain)
 		if err != nil {
-			return fmt.Errorf("error deleting ip%stables rule for logging packets to dummy device: %v", "", err)
+			return fmt.Errorf("error deleting ip%stables rule for logging packets to dummy device: %w", "", err)
 		}
 	}
 
 	if err := DefaultNetUtilsCommandExecutor.ExecuteIPTablesCommand("6", "-t", "mangle", "-C", "POSTROUTING", "-o", dummyDeviceName, "-j", ipTablesLoggingChain); err == nil {
 		err = DefaultNetUtilsCommandExecutor.ExecuteIPTablesCommand("6", "-t", "mangle", "-D", "POSTROUTING", "-o", dummyDeviceName, "-j", ipTablesLoggingChain)
 		if err != nil {
-			return fmt.Errorf("error deleting ip%stables rule for logging packets to dummy device: %v", "6", err)
+			return fmt.Errorf("error deleting ip%stables rule for logging packets to dummy device: %w", "6", err)
 		}
 	}
 
@@ -327,11 +327,11 @@ func RemoveDummyDevice() error {
 	if strings.Contains(out.String(), " "+dummyDeviceName+": ") {
 		_, err := DefaultNetUtilsCommandExecutor.ExecuteIPRouteCommand("4", "link", "set", dummyDeviceName, "down")
 		if err != nil {
-			return fmt.Errorf("error bringing down dummy device: %v", err)
+			return fmt.Errorf("error bringing down dummy device: %w", err)
 		}
 		_, err = DefaultNetUtilsCommandExecutor.ExecuteIPRouteCommand("4", "link", "del", dummyDeviceName)
 		if err != nil {
-			return fmt.Errorf("error deleting dummy device: %v", err)
+			return fmt.Errorf("error deleting dummy device: %w", err)
 		}
 		fmt.Println("Removed dummy device.")
 	}

--- a/pkg/netconfig/netconfig_test.go
+++ b/pkg/netconfig/netconfig_test.go
@@ -78,24 +78,24 @@ var _ = Describe("Netconfig", func() {
 	Describe("IPTablesLoggingChainRule", func() {
 
 		DescribeTable("calls the correct command with the correct arguments",
-			func(ipVersion, protocol, ipSet, device string, check bool, delete bool, blockIngress bool, expectedArgs []string) {
-				err := netconfig.IPTablesLoggingChainRule(ipVersion, protocol, ipSet, device, check, delete, blockIngress)
+			func(ipVersion, protocol, ipSet, device string, action netconfig.IPTablesAction, blockIngress bool, expectedArgs []string) {
+				err := netconfig.IPTablesLoggingChainRule(ipVersion, protocol, ipSet, device, action, blockIngress)
 				Expect(err).To(BeNil())
 				Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[0].Args).To(Equal(expectedArgs))
 			},
-			Entry("add rule", "", "tcp", "test-ipset", "ens5", false, false, false, []string{
+			Entry("add rule", "", "tcp", "test-ipset", "ens5", netconfig.IPTablesAppend, false, []string{
 				"iptables-legacy", "-w", "-t", "mangle", "-A", "POSTROUTING", "-o", "ens5", "-p", "tcp", "--syn", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING",
 			}),
-			Entry("add rule with block-ingress", "", "tcp", "test-ipset", "ens5", false, false, true, []string{
+			Entry("add rule with block-ingress", "", "tcp", "test-ipset", "ens5", netconfig.IPTablesAppend, true, []string{
 				"iptables-legacy", "-w", "-t", "mangle", "-A", "POSTROUTING", "-o", "ens5", "-p", "tcp", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING",
 			}),
-			Entry("check rule", "", "udp", "test-ipset", "ens5", true, false, false, []string{
+			Entry("check rule", "", "udp", "test-ipset", "ens5", netconfig.IPTablesCheck, false, []string{
 				"iptables-legacy", "-w", "-t", "mangle", "-C", "POSTROUTING", "-o", "ens5", "-p", "udp", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING",
 			}),
-			Entry("delete rule", "", "tcp", "test-ipset", "ens5", true, true, false, []string{
+			Entry("delete rule", "", "tcp", "test-ipset", "ens5", netconfig.IPTablesDelete, false, []string{
 				"iptables-legacy", "-w", "-t", "mangle", "-D", "POSTROUTING", "-o", "ens5", "-p", "tcp", "--syn", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING",
 			}),
-			Entry("add rule with different ip version", "6", "tcp", "test-ipset", "ens5", false, false, false, []string{
+			Entry("add rule with different ip version", "6", "tcp", "test-ipset", "ens5", netconfig.IPTablesAppend, false, []string{
 				"ip6tables-legacy", "-w", "-t", "mangle", "-A", "POSTROUTING", "-o", "ens5", "-p", "tcp", "--syn", "-m", "set", "--match-set", "test-ipset", "dst", "-j", "POLICY_LOGGING",
 			}),
 		)

--- a/pkg/netconfig/netconfig_test.go
+++ b/pkg/netconfig/netconfig_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Netconfig", func() {
 
 		DescribeTable("calls the correct command with the correct arguments",
 			func(ipVersion, protocol, ipSet, device string, check bool, expectedArgs []string) {
-				err := netconfig.IPTablesLoggingChainRule(ipVersion, protocol, ipSet, device, check, false)
+				err := netconfig.IPTablesLoggingChainRule(ipVersion, protocol, ipSet, device, check, false, false)
 				Expect(err).To(BeNil())
 				Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[0].Args).To(Equal(expectedArgs))
 			},
@@ -229,7 +229,35 @@ line with []
 			Expect(err).To(BeNil())
 			Expect(len(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds)).To(Equal(1))
 			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[0].Args).To(Equal([]string{"ip", "-4", "route"}))
+		})
+		It("correct commands are called, when there is no change for ipv6", func() {
+			ipList := `
+			line with []
+			- 2001:16c0:a::/48
+			- 2001:3040::/29
+			- 2001:3b80::
+			- 2001:4188::/29
+			- 2001:4860:7:214::/64
+			- 2401:4900:33d5:4afa:9d59:6c45:239f:8ead/128
+			- 2406:840:9680:666::/64
 
+			`
+			mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
+			sb := strings.Builder{}
+			sb.WriteString("2001:16c0:a::/48 dev dummy0 scope link \n")
+			sb.WriteString("2001:3040::/29 dev dummy0 scope link \n")
+			sb.WriteString("2001:3b80:: dev dummy0 scope link \n")
+			sb.WriteString("2001:4188::/29 dev dummy0 scope link \n")
+			sb.WriteString("2001:4860:7:214::/64 dev dummy0 scope link \n")
+			sb.WriteString("2401:4900:33d5:4afa:9d59:6c45:239f:8ead dev dummy0 scope link \n")
+			sb.WriteString("2406:840:9680:666::/64 dev dummy0 scope link")
+
+			mockExecutor.MockIPRoutesStdOut = bytes.NewBufferString(sb.String())
+			netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
+			err := netconfig.UpdateRoutes("6", ipList)
+			Expect(err).To(BeNil())
+			Expect(len(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds)).To(Equal(1))
+			Expect(netconfig.DefaultNetUtilsCommandExecutor.(*netconfig.MockNetUtilsCommandExecutor).MockCmds[0].Args).To(Equal([]string{"ip", "-6", "route"}))
 		})
 		It("correct commands are called, when there is no change for ipv6", func() {
 			ipList := `

--- a/pkg/netconfig/netconfig_test.go
+++ b/pkg/netconfig/netconfig_test.go
@@ -5,7 +5,6 @@
 package netconfig_test
 
 import (
-	"bytes"
 	"errors"
 	"io"
 	"strings"
@@ -21,7 +20,7 @@ var _ = Describe("Netconfig", func() {
 	BeforeEach(func() {
 		mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
 		mockExecutor.DetermineIPTablesBackend()
-		mockExecutor.MockIPRoutesStdOut = bytes.NewBufferString("default via 10.242.0.1 dev ens5 proto dhcp src 10.242.0.198 metric 1024")
+		mockExecutor.MockIPRoutesStdOut = "default via 10.242.0.1 dev ens5 proto dhcp src 10.242.0.198 metric 1024"
 		netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
 
 	})
@@ -34,7 +33,7 @@ var _ = Describe("Netconfig", func() {
 	Describe("GetDefaultNetworkDevice", func() {
 		It("returns correct device name", func() {
 			mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
-			mockExecutor.MockIPRoutesStdOut = bytes.NewBufferString("default via 10.242.0.1 dev ens5 proto dhcp src 10.242.0.198 metric 1024")
+			mockExecutor.MockIPRoutesStdOut = "default via 10.242.0.1 dev ens5 proto dhcp src 10.242.0.198 metric 1024"
 			netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
 			device, err := netconfig.GetDefaultNetworkDevice("4")
 			Expect(err).To(BeNil())
@@ -42,7 +41,7 @@ var _ = Describe("Netconfig", func() {
 		})
 		It("returns an error if no device found", func() {
 			mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
-			mockExecutor.MockIPRoutesStdOut = bytes.NewBufferString("Error: any valid prefix is expected rather than \"default\".")
+			mockExecutor.MockIPRoutesStdOut = "Error: any valid prefix is expected rather than \"default\"."
 			netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
 			device, err := netconfig.GetDefaultNetworkDevice("4")
 			Expect(err).NotTo(BeNil())
@@ -113,7 +112,7 @@ var _ = Describe("Netconfig", func() {
 		It("makes the right calls to iptables if rules don't exist", func() {
 			mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
 			mockExecutor.DetermineIPTablesBackend()
-			mockExecutor.MockIPRoutesStdOut = bytes.NewBufferString("default via 10.242.0.1 dev ens5 proto dhcp src 10.242.0.198 metric 1024")
+			mockExecutor.MockIPRoutesStdOut = "default via 10.242.0.1 dev ens5 proto dhcp src 10.242.0.198 metric 1024"
 			mockExecutor.MockCheckError = errors.New("iptables: Bad rule (does a matching rule exist in that chain?).")
 			netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
 
@@ -142,7 +141,7 @@ var _ = Describe("Netconfig", func() {
 		It("makes the right calls to iptables if rules don't exist", func() {
 			mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
 			mockExecutor.DetermineIPTablesBackend()
-			mockExecutor.MockIPRoutesStdOut = bytes.NewBufferString("default via 10.242.0.1 dev ens5 proto dhcp src 10.242.0.198 metric 1024")
+			mockExecutor.MockIPRoutesStdOut = "default via 10.242.0.1 dev ens5 proto dhcp src 10.242.0.198 metric 1024"
 			mockExecutor.MockCheckError = errors.New("iptables: Bad rule (does a matching rule exist in that chain?).")
 			netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
 			err := netconfig.RemoveIPTablesLoggingRules("4", "test-ipset", "ens5")
@@ -235,7 +234,7 @@ line with []
 
 	Describe("GetBlackholeRoutes", func() {
 		mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
-		mockExecutor.MockIPRoutesStdOut = bytes.NewBufferString("1.2.3.4/32 dev dummy0 scope link \n5.2.3.4/30 dev dummy0 scope link")
+		mockExecutor.MockIPRoutesStdOut = "1.2.3.4/32 dev dummy0 scope link \n5.2.3.4/30 dev dummy0 scope link"
 		netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
 		blackholeIPs, err := netconfig.GetBlackholeRoutes("4")
 		Expect(err).To(BeNil())
@@ -254,7 +253,7 @@ line with []
 			
 			`
 			mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
-			mockExecutor.MockIPRoutesStdOut = bytes.NewBufferString("1.2.3.4 dev dummy0 scope link \n5.2.3.4/30 dev dummy0 scope link")
+			mockExecutor.MockIPRoutesStdOut = "1.2.3.4 dev dummy0 scope link \n5.2.3.4/30 dev dummy0 scope link"
 			netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
 			err := netconfig.UpdateRoutes("4", ipList)
 			Expect(err).To(BeNil())
@@ -272,7 +271,7 @@ line with []
 			
 			`
 			mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
-			mockExecutor.MockIPRoutesStdOut = bytes.NewBufferString("1.2.3.4 dev dummy0 scope link \n5.2.3.4/30 dev dummy0 scope link")
+			mockExecutor.MockIPRoutesStdOut = "1.2.3.4 dev dummy0 scope link \n5.2.3.4/30 dev dummy0 scope link"
 			netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
 			err := netconfig.UpdateRoutes("4", ipList)
 			Expect(err).To(BeNil())
@@ -301,7 +300,7 @@ line with []
 			sb.WriteString("2401:4900:33d5:4afa:9d59:6c45:239f:8ead dev dummy0 scope link \n")
 			sb.WriteString("2406:840:9680:666::/64 dev dummy0 scope link")
 
-			mockExecutor.MockIPRoutesStdOut = bytes.NewBufferString(sb.String())
+			mockExecutor.MockIPRoutesStdOut = sb.String()
 			netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
 			err := netconfig.UpdateRoutes("6", ipList)
 			Expect(err).To(BeNil())
@@ -330,7 +329,7 @@ line with []
 			sb.WriteString("2401:4900:33d5:4afa:9d59:6c45:239f:8ead dev dummy0 scope link \n")
 			sb.WriteString("2406:840:9680:666::/64 dev dummy0 scope link")
 
-			mockExecutor.MockIPRoutesStdOut = bytes.NewBufferString(sb.String())
+			mockExecutor.MockIPRoutesStdOut = sb.String()
 			netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
 			err := netconfig.UpdateRoutes("6", ipList)
 			Expect(err).To(BeNil())

--- a/pkg/netconfig/netconfig_test.go
+++ b/pkg/netconfig/netconfig_test.go
@@ -243,6 +243,40 @@ line with []
 		Expect(blackholeIPs[1]).To(Equal("5.2.3.4/30"))
 	})
 
+	Describe("InitDummyDevice", func() {
+		It("does not fail if dummy0 already exists", func() {
+			mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
+			mockExecutor.MockIPRoutesStdOut = "36: dummy0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000 link/ether e2:90:98:7e:4d:32 brd ff:ff:ff:ff:ff:ff"
+			netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
+			err := netconfig.InitDummyDevice()
+			Expect(err).To(BeNil())
+		})
+		It("does not fail if dummy0 does not exist", func() {
+			mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
+			mockExecutor.MockIPRoutesStdOut = "1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000 link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00"
+			netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
+			err := netconfig.InitDummyDevice()
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Describe("RemoveDummyDevice", func() {
+		It("does not fail if dummy0 already exists", func() {
+			mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
+			mockExecutor.MockIPRoutesStdOut = "36: dummy0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000 link/ether e2:90:98:7e:4d:32 brd ff:ff:ff:ff:ff:ff"
+			netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
+			err := netconfig.RemoveDummyDevice()
+			Expect(err).To(BeNil())
+		})
+		It("does not fail if dummy0 does not exist", func() {
+			mockExecutor := &netconfig.MockNetUtilsCommandExecutor{}
+			mockExecutor.MockIPRoutesStdOut = "1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000 link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00"
+			netconfig.DefaultNetUtilsCommandExecutor = mockExecutor
+			err := netconfig.RemoveDummyDevice()
+			Expect(err).To(BeNil())
+		})
+	})
+
 	Describe("UpdateRoutes", func() {
 		It("correct commands are called", func() {
 			ipList := `

--- a/pkg/netconfig/netutils.go
+++ b/pkg/netconfig/netutils.go
@@ -7,6 +7,7 @@ package netconfig
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -15,7 +16,7 @@ import (
 type NetUtilsCommandExecutor interface {
 	DetermineIPTablesBackend()
 	ExecuteIPTablesCommand(ipVersion string, args ...string) error
-	ExecuteIPRouteCommand(ipVersion string, args ...string) (*bytes.Buffer, error)
+	ExecuteIPRouteCommand(ipVersion string, args ...string) (string, error)
 	ExecuteIPSetCommand(args ...string) error
 	ExecuteIPSetScript(ipSetScript string) error
 	ExecuteIPRouteBatchCommand(ipVersion, script string) error
@@ -51,13 +52,10 @@ func (r *OSNetUtilsCommandExecutor) DetermineIPTablesBackend() {
 	}
 }
 
-func (r *OSNetUtilsCommandExecutor) ExecuteIPRouteCommand(ipVersion string, args ...string) (*bytes.Buffer, error) {
+func (r *OSNetUtilsCommandExecutor) ExecuteIPRouteCommand(ipVersion string, args ...string) (string, error) {
 	args = append([]string{"-" + ipVersion}, args...)
-	cmd := exec.Command("ip", args...)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err := cmd.Run()
-	return &out, err
+	out, err := wrapCmd("ip", args...)
+	return out, err
 }
 
 func (r *OSNetUtilsCommandExecutor) ExecuteIPRouteBatchCommand(ipVersion, script string) error {
@@ -72,8 +70,8 @@ func (r *OSNetUtilsCommandExecutor) ExecuteIPRouteBatchCommand(ipVersion, script
 		return fmt.Errorf("error creating tmp file for ip route batch processing: %v", err)
 	}
 
-	cmd := exec.Command("ip", "-"+ipVersion, "-batch", tmpFile.Name()) // #nosec: G204 -- Almost static command (ip -(4|6) -batch tmpFile) with only the tmpFile being dynamic
-	return wrapCmd(cmd)
+	_, err = wrapCmd("ip", "-"+ipVersion, "-batch", tmpFile.Name())
+	return err
 }
 
 func (r *OSNetUtilsCommandExecutor) ExecuteIPTablesCommand(ipVersion string, args ...string) error {
@@ -81,37 +79,49 @@ func (r *OSNetUtilsCommandExecutor) ExecuteIPTablesCommand(ipVersion string, arg
 		ipVersion = ""
 	}
 	args = append([]string{"-w"}, args...)
-	cmd := exec.Command("ip"+ipVersion+"tables-"+r.ipTablesBackend, args...) // #nosec: G204 -- Very limited set of static commands using (ip|ip6)tables-(legacy|nft).
-	return wrapCmd(cmd)
+	_, err := wrapCmd("ip"+ipVersion+"tables-"+r.ipTablesBackend, args...)
+	return err
 }
 
 func (r *OSNetUtilsCommandExecutor) ExecuteIPSetCommand(args ...string) error {
-	cmd := exec.Command("ipset", args...)
-	return wrapCmd(cmd)
+	_, err := wrapCmd("ipset", args...)
+	return err
 }
 
 func (r *OSNetUtilsCommandExecutor) ExecuteIPSetScript(script string) error {
-	cmd := exec.Command("ipset", "-")
-	cmd.Stdin = strings.NewReader(script)
-	return wrapCmd(cmd)
+	_, err := wrapCmdStdin("ipset", strings.NewReader(script), "-")
+	return err
 }
 
-func wrapCmd(cmd *exec.Cmd) error {
-	outbytes, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("%w: %s", err, outbytes)
+func wrapCmd(name string, arg ...string) (string, error) {
+	return wrapCmdStdin(name, nil, arg...)
+}
+
+func wrapCmdStdin(name string, stdIn io.Reader, arg ...string) (string, error) {
+	cmd := exec.Command(name, arg...)
+	var stdOut, stdErr bytes.Buffer
+	cmd.Stdout = &stdOut
+	cmd.Stderr = &stdErr
+	if stdIn != nil {
+		cmd.Stdin = stdIn
 	}
-	return nil
+	err := cmd.Run()
+
+	if err != nil {
+		return "", fmt.Errorf("%w: stdout: %s  stderr: %s", err, stdOut.String(), stdErr.String())
+	}
+
+	return stdOut.String(), nil
 }
 
 type MockNetUtilsCommandExecutor struct {
 	MockCmds           []*exec.Cmd
-	MockIPRoutesStdOut *bytes.Buffer
+	MockIPRoutesStdOut string
 	MockCheckError     error
 	ipTablesBackend    string
 }
 
-func (m *MockNetUtilsCommandExecutor) ExecuteIPRouteCommand(ipVersion string, args ...string) (*bytes.Buffer, error) {
+func (m *MockNetUtilsCommandExecutor) ExecuteIPRouteCommand(ipVersion string, args ...string) (string, error) {
 	args = append([]string{"-" + ipVersion}, args...)
 	cmd := exec.Command("ip", args...)
 	m.MockCmds = append(m.MockCmds, cmd)


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, if the blocking mode changed the old rules were not removed from the node.
i.e. if blackholing was enabled and the shoot got reconciled with blackholing disabled, the old blackhole routes still remained active.

The logic was changed such that we 
- First apply the new rules
- Then delete the opposite mode

i.e. if blackholing got enabled, we first apply blackhole routes and then delete ipsets and iptables rules and vice versa. 

The reason for this logic is to avoid having an in-between state where no egress filtering is applied. We delete the old rules only after the new ones have been applied successfully.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
On switching the blocking mode, previously active egress filter rules are removed from the node.
```
