### PR TITLE
Introduce `gosec` for Static Application Security Testing (SAST)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ local/
 .kube/
 .vscode/
 filter-updater
+
+# gosec
+gosec-report.sarif

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,17 @@ tidy:
 	@GO111MODULE=on go mod tidy
 
 .PHONY: check
-check: $(GOIMPORTS) $(GOLANGCI_LINT)
+check: $(GOIMPORTS) $(GOLANGCI_LINT) sast-report
 	go vet ./...
 	GOIMPORTS=$(GOIMPORTS) GOLANGCI_LINT=$(GOLANGCI_LINT) hack/check.sh ./pkg/...
+
+.PHONY: sast
+sast: $(GOSEC)
+	@./hack/sast.sh
+
+.PHONY: sast-report
+sast-report: $(GOSEC)
+	@./hack/sast.sh --gosec-report true
 
 .PHONY: test
 test:

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+
+gosec_report="false"
+gosec_report_parse_flags=""
+
+parse_flags() {
+  while test $# -gt 1; do
+    case "$1" in
+      --gosec-report)
+        shift; gosec_report="$1"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_flags "$@"
+
+echo "> Running gosec"
+gosec --version
+if [[ "$gosec_report" != "false" ]]; then
+  echo "Exporting report to $root_dir/gosec-report.sarif"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
+fi
+
+# Gardener uses code-generators https://github.com/kubernetes/code-generator and https://github.com/protocolbuffers/protobuf
+# which create lots of G103 (CWE-242: Use of unsafe calls should be audited) & G104 (CWE-703: Errors unhandled) errors.
+# However, those generators are best-pratice in Kubernetes environment and their results are tested well.
+# Thus, generated code is excluded from gosec scan.
+# Nested go modules are not supported by gosec (see https://github.com/securego/gosec/issues/501), so the ./hack folder
+# is excluded too. It does not contain productive code anyway.
+gosec -exclude-generated -exclude-dir=hack $gosec_report_parse_flags ./...
+

--- a/hack/tools/install-gosec.sh
+++ b/hack/tools/install-gosec.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+echo "> Installing gosec"
+
+TOOLS_BIN_DIR=${TOOLS_BIN_DIR:-$(dirname $0)/bin}
+
+platform=$(uname -s | tr '[:upper:]' '[:lower:]')
+version=$GOSEC_VERSION
+case $(uname -m) in
+  aarch64 | arm64)
+    arch="arm64"
+    ;;
+  x86_64)
+    arch="amd64"
+    ;;
+  *)
+    echo "Unknown architecture"
+    exit -1
+    ;;
+esac
+
+archive_name="gosec_${version#v}_${platform}_${arch}"
+file_name="${archive_name}.tar.gz"
+
+temp_dir="$(mktemp -d)"
+function cleanup {
+  rm -rf "${temp_dir}"
+}
+trap cleanup EXIT ERR INT TERM
+
+curl -L -o ${temp_dir}/${file_name} "https://github.com/securego/gosec/releases/download/${version}/${file_name}"
+
+tar -xzm -C "${temp_dir}" -f "${temp_dir}/${file_name}"
+mv "${temp_dir}/gosec" $TOOLS_BIN_DIR
+chmod +x $TOOLS_BIN_DIR/gosec
+

--- a/hack/tools/tools.mk
+++ b/hack/tools/tools.mk
@@ -5,6 +5,9 @@
 TOOLS_BIN_DIR              := $(TOOLS_DIR)/bin
 GOIMPORTS                  := $(TOOLS_BIN_DIR)/goimports
 GOLANGCI_LINT              := $(TOOLS_BIN_DIR)/golangci-lint
+GOSEC                      := $(TOOLS_BIN_DIR)/gosec
+
+export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)
 
 #########################################
 # Common                                #
@@ -34,7 +37,10 @@ clean-tools-bin:
 	rm -rf $(TOOLS_BIN_DIR)/*
 
 # default tool versions
+# renovate: datasource=github-releases depName=golangci/golangci-lint
 GOLANGCI_LINT_VERSION ?= v1.55.1
+# renovate: datasource=github-releases depName=securego/gosec
+GOSEC_VERSION ?= v2.20.0
 
 GOIMPORTS_VERSION ?= $(call version_gomod,golang.org/x/tools)
 
@@ -45,3 +51,6 @@ $(GOLANGCI_LINT): $(call tool_version_file,$(GOLANGCI_LINT),$(GOLANGCI_LINT_VERS
 	@# CGO_ENABLED has to be set to 1 in order for golangci-lint to be able to load plugins
 	@# see https://github.com/golangci/golangci-lint/issues/1276
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) CGO_ENABLED=1 go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+$(GOSEC): $(call tool_version_file,$(GOSEC),$(GOSEC_VERSION))
+	@GOSEC_VERSION=$(GOSEC_VERSION) $(TOOLS_DIR)/install-gosec.sh

--- a/pkg/netconfig/netutils.go
+++ b/pkg/netconfig/netutils.go
@@ -67,7 +67,7 @@ func (r *OSNetUtilsCommandExecutor) ExecuteIPRouteBatchCommand(ipVersion, script
 	}
 	defer os.Remove(tmpFile.Name())
 
-	err = os.WriteFile(tmpFile.Name(), []byte(script), 0644)
+	err = os.WriteFile(tmpFile.Name(), []byte(script), 0600)
 	if err != nil {
 		return fmt.Errorf("Error creating tmp file for ip route batch processing: %v", err)
 	}

--- a/pkg/netconfig/netutils.go
+++ b/pkg/netconfig/netutils.go
@@ -72,7 +72,7 @@ func (r *OSNetUtilsCommandExecutor) ExecuteIPRouteBatchCommand(ipVersion, script
 		return fmt.Errorf("Error creating tmp file for ip route batch processing: %v", err)
 	}
 
-	cmd := exec.Command("ip", "-"+ipVersion, "-batch", tmpFile.Name())
+	cmd := exec.Command("ip", "-"+ipVersion, "-batch", tmpFile.Name()) // #nosec: G204 -- Almost static command (ip -(4|6) -batch tmpFile) with only the tmpFile being dynamic
 	return cmd.Run()
 }
 
@@ -81,7 +81,7 @@ func (r *OSNetUtilsCommandExecutor) ExecuteIPTablesCommand(ipVersion string, arg
 		ipVersion = ""
 	}
 	args = append([]string{"-w"}, args...)
-	cmd := exec.Command("ip"+ipVersion+"tables-"+r.ipTablesBackend, args...)
+	cmd := exec.Command("ip"+ipVersion+"tables-"+r.ipTablesBackend, args...) // #nosec: G204 -- Very limited set of static commands using (ip|ip6)tables-(legacy|nft).
 	return cmd.Run()
 }
 
@@ -115,7 +115,7 @@ func (m *MockNetUtilsCommandExecutor) ExecuteIPTablesCommand(ipVersion string, a
 		ipVersion = ""
 	}
 	args = append([]string{"-w"}, args...)
-	cmd := exec.Command("ip"+ipVersion+"tables-"+m.ipTablesBackend, args...)
+	cmd := exec.Command("ip"+ipVersion+"tables-"+m.ipTablesBackend, args...) // #nosec: G204 -- Test only.
 	m.MockCmds = append(m.MockCmds, cmd)
 	if args[3] == "-C" || args[3] == "-L" {
 		return m.MockCheckError
@@ -140,7 +140,7 @@ func (m *MockNetUtilsCommandExecutor) ExecuteIPSetScript(script string) error {
 }
 
 func (m *MockNetUtilsCommandExecutor) ExecuteIPRouteBatchCommand(ipVersion, script string) error {
-	cmd := exec.Command("ip", "-"+ipVersion, "-batch", "tmpFile")
+	cmd := exec.Command("ip", "-"+ipVersion, "-batch", "tmpFile") // #nosec: G204 -- Test only.
 	cmd.Stdin = strings.NewReader(script)
 	m.MockCmds = append(m.MockCmds, cmd)
 	return nil


### PR DESCRIPTION
/area networking
/area security
/area compliance
/kind enhancement

**What this PR does / why we need it**:

This PR introduces `gosec` for Static Application Security Testing at Gardener and should replace other code scanners.

It uses the default ruleset of `gosec` similar to what was introduced to gardener/gardener in https://github.com/gardener/gardener/pull/9959.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`gosec` was introduced for Static Application Security Testing (SAST).
```
