### PR TITLE
bump golangci-lint

### DIFF
--- a/hack/tools/tools.mk
+++ b/hack/tools/tools.mk
@@ -38,7 +38,7 @@ clean-tools-bin:
 
 # default tool versions
 # renovate: datasource=github-releases depName=golangci/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.55.1
+GOLANGCI_LINT_VERSION ?= v1.61.0
 # renovate: datasource=github-releases depName=securego/gosec
 GOSEC_VERSION ?= v2.20.0
 


### PR DESCRIPTION
bring it on par with [gardener/gardener](https://github.com/gardener/gardener/blob/master/hack/tools.mk#L54)

**What this PR does / why we need it**:

unblock build, see [verify task](https://concourse.ci.gardener.cloud/teams/gardener/pipelines/egress-filter-refresher-master/jobs/master-head-update-job/builds/46) in head update job.

**Special notes for your reviewer**:
My assumption is that the version is controlled by renovate but it seems not to bump it yet. So until that's fixed I've opened this PR to unblock the build.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
