### PR TITLE
auto-merge go versions in github actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,6 +23,7 @@
       "matchPackagePatterns": [
         "^actions/checkout$",
         "^actions/setup-go$",
+        "^actions/go-versions$",
       ],
       "automerge": true
     },


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**Which issue(s) this PR fixes**:
Fixes automerge of https://github.com/gardener/egress-filter-refresher/pull/108


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
